### PR TITLE
`String#to_i` should respect original base argument

### DIFF
--- a/roman_numerals/roman_numerals_medium.rb
+++ b/roman_numerals/roman_numerals_medium.rb
@@ -15,8 +15,8 @@ module Roman
     end
 
     alias_method :to_i_orig, :to_i
-    def to_i(type=nil)
-      type == :roman ? RomanNumerals.new.to_i(self) : self.to_i_orig
+    def to_i(base=10, type: nil)
+      type && type == :roman ? RomanNumerals.new.to_i(self) : self.to_i_orig(base)
     end
   end
 end

--- a/roman_numerals/roman_numerals_medium_test.rb
+++ b/roman_numerals/roman_numerals_medium_test.rb
@@ -8,92 +8,92 @@ using Roman
 class RomanNumeralsTest < Minitest::Test
   def test_1
     assert_equal 'I', 1.to_roman
-    assert_equal 1, 'I'.to_i(:roman)
+    assert_equal 1, 'I'.to_i(type: :roman)
   end
 
   def test_2
     assert_equal 'II', 2.to_roman
-    assert_equal  2, 'II'.to_i(:roman)
+    assert_equal  2, 'II'.to_i(type: :roman)
   end
 
   def test_3
     assert_equal 'III', 3.to_roman
-    assert_equal 3, 'III'.to_i(:roman)
+    assert_equal 3, 'III'.to_i(type: :roman)
   end
 
   def test_4
     assert_equal 'IV', 4.to_roman
-    assert_equal 4, 'IV'.to_i(:roman)
+    assert_equal 4, 'IV'.to_i(type: :roman)
   end
 
   def test_5
     assert_equal 'V', 5.to_roman
-    assert_equal 5, 'V'.to_i(:roman)
+    assert_equal 5, 'V'.to_i(type: :roman)
   end
 
   def test_6
     assert_equal 'VI', 6.to_roman
-    assert_equal 6, 'VI'.to_i(:roman)
+    assert_equal 6, 'VI'.to_i(type: :roman)
   end
 
   def test_9
     assert_equal 'IX', 9.to_roman
-    assert_equal 9, 'IX'.to_i(:roman)
+    assert_equal 9, 'IX'.to_i(type: :roman)
   end
 
   def test_27
     assert_equal 'XXVII', 27.to_roman
-    assert_equal 27, 'XXVII'.to_i(:roman)
+    assert_equal 27, 'XXVII'.to_i(type: :roman)
   end
 
   def test_48
     assert_equal 'XLVIII', 48.to_roman
-    assert_equal 48, 'XLVIII'.to_i(:roman)
+    assert_equal 48, 'XLVIII'.to_i(type: :roman)
   end
 
   def test_59
     assert_equal 'LIX', 59.to_roman
-    assert_equal 59, 'LIX'.to_i(:roman)
+    assert_equal 59, 'LIX'.to_i(type: :roman)
   end
 
   def test_93
     assert_equal 'XCIII', 93.to_roman
-    assert_equal 93, 'XCIII'.to_i(:roman)
+    assert_equal 93, 'XCIII'.to_i(type: :roman)
   end
 
   def test_141
     assert_equal 'CXLI', 141.to_roman
-    assert_equal 141, 'CXLI'.to_i(:roman)
+    assert_equal 141, 'CXLI'.to_i(type: :roman)
   end
 
   def test_163
     assert_equal 'CLXIII', 163.to_roman
-    assert_equal 163, 'CLXIII'.to_i(:roman)
+    assert_equal 163, 'CLXIII'.to_i(type: :roman)
   end
 
   def test_402
     assert_equal 'CDII', 402.to_roman
-    assert_equal 402, 'CDII'.to_i(:roman)
+    assert_equal 402, 'CDII'.to_i(type: :roman)
   end
 
   def test_575
     assert_equal 'DLXXV', 575.to_roman
-    assert_equal 575, 'DLXXV'.to_i(:roman)
+    assert_equal 575, 'DLXXV'.to_i(type: :roman)
   end
 
   def test_911
     assert_equal 'CMXI', 911.to_roman
-    assert_equal 911, 'CMXI'.to_i(:roman)
+    assert_equal 911, 'CMXI'.to_i(type: :roman)
   end
 
   def test_1024
     assert_equal 'MXXIV', 1024.to_roman
-    assert_equal 1024, 'MXXIV'.to_i(:roman)
+    assert_equal 1024, 'MXXIV'.to_i(type: :roman)
   end
 
   def test_3000
     assert_equal 'MMM', 3000.to_roman
-    assert_equal 3000, 'MMM'.to_i(:roman)
+    assert_equal 3000, 'MMM'.to_i(type: :roman)
   end
 end
 


### PR DESCRIPTION
The [`String#to_i`](http://ruby-doc.org/core-2.3.1/String.html#method-i-to_i) method breaks before this Pull Request:

``` ruby
> "1001".to_i 2
=> 9

> using Roman

> "1001".to_i 2
=> "1001" # should be 9
```

This Pull Request use keyword argument to workaround it.
